### PR TITLE
[feat] [#26] 관리자 설정 뷰 UI 구현

### DIFF
--- a/AhnNyeong/AhnNyeong.xcodeproj/project.pbxproj
+++ b/AhnNyeong/AhnNyeong.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		7DF11C2B2AB03D8F005C0AE3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7DF11C2A2AB03D8F005C0AE3 /* Assets.xcassets */; };
 		7DF11C2E2AB03D8F005C0AE3 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7DF11C2D2AB03D8F005C0AE3 /* Preview Assets.xcassets */; };
 		8E1DB0AE2AE4F522008DAD0F /* LoginTypeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E1DB0AD2AE4F522008DAD0F /* LoginTypeView.swift */; };
+		8E86F1642AEB461F00A04390 /* MngSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E86F1632AEB461F00A04390 /* MngSettingView.swift */; };
 		DEEBFF012AE4FD8D005098E3 /* ManagerViewForMVP.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEBFF002AE4FD8D005098E3 /* ManagerViewForMVP.swift */; };
 /* End PBXBuildFile section */
 
@@ -69,6 +70,7 @@
 		7DF11C2A2AB03D8F005C0AE3 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		7DF11C2D2AB03D8F005C0AE3 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		8E1DB0AD2AE4F522008DAD0F /* LoginTypeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTypeView.swift; sourceTree = "<group>"; };
+		8E86F1632AEB461F00A04390 /* MngSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MngSettingView.swift; sourceTree = "<group>"; };
 		DEEBFF002AE4FD8D005098E3 /* ManagerViewForMVP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagerViewForMVP.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -164,6 +166,7 @@
 				7DF11C282AB03D8E005C0AE3 /* ContentView.swift */,
 				7DF11C2A2AB03D8F005C0AE3 /* Assets.xcassets */,
 				7DF11C2C2AB03D8F005C0AE3 /* Preview Content */,
+				8E86F1632AEB461F00A04390 /* MngSettingView.swift */,
 			);
 			path = AhnNyeong;
 			sourceTree = "<group>";
@@ -312,6 +315,7 @@
 			files = (
 				7D5375FF2ADD63DF00D338D5 /* MensInfo.swift in Sources */,
 				DEEBFF012AE4FD8D005098E3 /* ManagerViewForMVP.swift in Sources */,
+				8E86F1642AEB461F00A04390 /* MngSettingView.swift in Sources */,
 				7DF11C292AB03D8E005C0AE3 /* ContentView.swift in Sources */,
 				7D5376072AE0166200D338D5 /* EditView.swift in Sources */,
 				7DF11C272AB03D8E005C0AE3 /* AhnNyeongApp.swift in Sources */,

--- a/AhnNyeong/AhnNyeong/MngSettingView.swift
+++ b/AhnNyeong/AhnNyeong/MngSettingView.swift
@@ -1,0 +1,119 @@
+//
+//  MngSettingView.swift
+//  AhnNyeong
+//
+//  Created by OhSuhyun on 2023.10.27.
+//
+
+import SwiftUI
+
+struct MngSettingView: View {
+    let userName: String
+    let pageSize = 25.0
+    var body: some View {
+        VStack(alignment: .center, spacing: 0) {
+            HStack(spacing: 8) {
+                Image(systemName: "checkmark.shield")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                Text("\(userName) 사회복지사님")
+                    .font(.system(size: pageSize, weight: .semibold))
+                Image(systemName: "pencil.circle")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .foregroundColor(.gray)
+            }
+            .frame(height: 24)
+            .padding(.top, 120)
+            Text("기관 인증됨")
+                .font(.system(size: 12, weight: .light))
+                .foregroundColor(.white)
+                .padding(.all, 4)
+                .background {
+                    Rectangle()
+                        .cornerRadius(4.0)
+                        .foregroundColor(.gray)
+                }
+                .padding(.top, 8)
+            Rectangle()
+                .roundedCorner(24.0, corners: [.topLeft, .topRight])
+                .foregroundColor(.white)
+                .shadow(color: .black.opacity(0.2), radius: 12.0, y: -4)
+                .padding(.top, 40)
+                .overlay {
+                    VStack(alignment: /*@START_MENU_TOKEN@*/.center/*@END_MENU_TOKEN@*/, spacing: 0) {
+                        List {
+                            Section {
+                                SettingList(listTitle: "데이터 관리", listCaption: "대상자와의 데이터를 추가 및 삭제할 수 있습니다.", navigationTo: "")
+                                SettingList(listTitle: "알람 설정", listCaption: "생리 현황 알림 받기의 시간대 설정 및 종류별 알림 활성화를 할 수 있습니다. ", navigationTo: "")
+                                SettingList(listTitle: "서비스 약관", listCaption: "개인정보처리방침 및 서비스 이용약관을 확인할 수 있습니다. ", navigationTo: "")
+                                SettingList(listTitle: "사용 가이드", listCaption: "대상자 앱의 사용 가이드 라인과 본 앱의 사용 가이드를 볼 수 있습니다. ", navigationTo: "")
+                                SettingList(listTitle: "이메일 문의", listCaption: "팀 ‘안녕'에게 하실 말씀이나 앱에 대한 개선점을 보내주세요.", navigationTo: "")
+                                Text("로그아웃")
+                                    .font(.system(size: 20.0, weight: .semibold))
+                                    .padding(.top, 16)
+                            } footer: {
+                                HStack(alignment: .center) {
+                                    Spacer()
+                                    Text("계정삭제")
+                                        .underline()
+                                        .foregroundColor(.gray)
+                                    Spacer()
+                                }
+                                .listRowSeparator(.hidden)
+                            }
+                        }
+                        .listStyle(.plain)
+                        Spacer()
+                    }
+                    .padding(.top, 64)
+                }
+        }
+        .ignoresSafeArea()
+    }
+}
+
+struct SettingList: View {
+    let listTitle: String
+    let listCaption: String
+    let navigationTo: String
+    let titleSize = 20.0
+    let captionSize = 11.0
+    var body: some View {
+        HStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 0) {
+                Text(listTitle)
+                    .font(.system(size: titleSize, weight: .semibold))
+                Text(listCaption)
+                    .font(.system(size: captionSize, weight: .light))
+                    .foregroundColor(.gray)
+            }
+            Spacer()
+            Image(systemName: "chevron.right")
+                .font(.system(size: titleSize, weight: .semibold))
+                .foregroundColor(.gray)
+        }
+        .padding(.top, 16)
+    }
+}
+
+#Preview {
+    MngSettingView(userName: "오복지")
+}
+
+// MARK: - for Specific Rounded Corners
+struct RoundedCorner: Shape {
+    var radius: CGFloat = .infinity
+    var corners: UIRectCorner = .allCorners
+    
+    func path(in rect: CGRect) -> Path {
+        let path = UIBezierPath(roundedRect: rect, byRoundingCorners: corners, cornerRadii: CGSize(width: radius, height: radius))
+        return Path(path.cgPath)
+    }
+}
+
+extension View {
+    func roundedCorner(_ radius: CGFloat, corners: UIRectCorner) -> some View {
+        clipShape(RoundedCorner(radius: radius, corners: corners) )
+    }
+}


### PR DESCRIPTION
<!--
---
name: PR template
about: 풀리퀘스트 보냅니다
title: "[feat][#0] 개발한 단위 기능의 이름"
labels: ''
assignees: ''

---
-->

📣 Assignees와 Labels를 우측에서 추가해 주세요!
# 📢 Description
<!-- 개발한 기능이 무엇인지, 수정한 버그가 무엇인지 설명해주세요 -->
- 관리자 설정 화면의 UI만 구현했습니다.
- onTapGesture 및 Navigation은 없습니다.
- 해당 화면을 사용할 때 이름을 매개변수로 전달해야 합니다.
  - MngSettingView(userName: "오복지")

# 🔑 Key Changes
<!-- 중심적으로 변화가 있는 부분을 명시해 주세요
- 버튼 생성
- 화면 로직 구현 등 -->
- 설정 리스트 아이템(타이틀, 캡션) 컴포넌트화
- 일부 모서리만 roundedCorner extension 추가

# 📸 Screenshots
<!-- 개발한 해당 부분의 스크린샷이나 영상을 첨부해 주세요 -->
<img width="200" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-AhnNyeong/assets/127754551/ac4c084d-0f44-48b8-b343-a50cf2b5eafb">


# 🙏 To Reviewers
<!-- 리뷰어가 확인하고 리뷰해 줬으면 좋겠는 부분을 알려주세요 -->
