### PR TITLE
[feat][#37] 알림 설정 화면 구현

### DIFF
--- a/AhnNyeong/AhnNyeong/UI/SettingViews/SettingNotiView.swift
+++ b/AhnNyeong/AhnNyeong/UI/SettingViews/SettingNotiView.swift
@@ -8,8 +8,135 @@
 import SwiftUI
 
 struct SettingNotiView: View {
+    @State var isMensToday = false
+    @State var isMensNotInit = false
+    @State var isMensBeforeWeek = false
+    @State var isOvulation = false
+    @State var startTime = Date()
+    @State var endTime = Date()
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack(alignment: .leading, spacing: 0) {
+            Text("알림 설정")
+                .font(.system(size: 28, weight: .bold))
+                .foregroundColor(.black400)
+                .padding(.horizontal, 16)
+            
+            DividingRectangle(dividingType: .naviTitleDivider)
+                .padding(.vertical, 20)
+            
+            VStack(alignment: .leading, spacing: 0) {
+                Text("개별 알림 활성화")
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundColor(.black400)
+                HStack(spacing: 0) {
+                    Text("활성화된 알람은 ")
+                    Text("오전 9시")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(.coral500)
+                    Text("에 일괄 전송됩니다.")
+                }
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(.black300)
+                .padding(.bottom, 20)
+                VStack(spacing: 0) {
+                    ToggleList(toggleTitle: "생리 예정 당일", toggleIsOn: $isMensToday)
+                    DividingRectangle(dividingType: .listDivider).padding(.leading, 16)
+                    ToggleList(toggleTitle: "주기 미입력 알람", toggleIsOn: $isMensNotInit)
+                    DividingRectangle(dividingType: .listDivider).padding(.leading, 16)
+                    ToggleList(toggleTitle: "생리 7일 전", toggleIsOn: $isMensBeforeWeek)
+                    DividingRectangle(dividingType: .listDivider).padding(.leading, 16)
+                    ToggleList(toggleTitle: "배란일", toggleIsOn: $isOvulation)
+                }
+                .font(.system(size: 16, weight: .medium))
+                .toggleStyle(SwitchToggleStyle(tint: .coral500))
+                .background {
+                    Rectangle()
+                        .foregroundColor(.white50)
+                        .cornerRadius(10)
+                }
+            }
+            .padding(.horizontal, 16)
+            
+            DividingRectangle(dividingType: .naviTitleDivider)
+                .padding(.vertical, 20)
+            
+            VStack(alignment: .leading, spacing: 0) {
+                ListTitle(listTitle: "생리 현황 알림 시간 지정", listCaption: "생리 현황 알림을 받을 시간대를 설정할 수 있습니다. ")
+                    .padding(.bottom, 20)
+                VStack(spacing: 0) {
+                    DatePickerList(datePickerTitle: "시작 시간", selection: $startTime)
+                    DividingRectangle(dividingType: .listDivider).padding(.leading, 16)
+                    DatePickerList(datePickerTitle: "종료 시간", selection: $endTime)
+                }
+                .font(.system(size: 16, weight: .medium))
+                .background {
+                    Rectangle()
+                        .foregroundColor(.white50)
+                        .cornerRadius(10)
+                }
+            }
+            .padding(.horizontal, 16)
+            Spacer()
+        }
+        .background(Color.white300)
+        
+    }
+}
+
+struct ListTitle: View {
+    let listTitle: String
+    let listCaption: String
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(listTitle)
+                .font(.system(size: 18, weight: .bold))
+                .foregroundColor(.black400)
+            Text(listCaption)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(.black300)
+        }
+    }
+}
+
+struct ToggleList: View {
+    let toggleTitle: String
+    @Binding var toggleIsOn: Bool
+    var body: some View {
+        Toggle(toggleTitle, isOn: $toggleIsOn)
+            .padding(.vertical, 6.5)
+            .padding(.horizontal, 16)
+    }
+}
+
+struct DatePickerList: View {
+    let datePickerTitle: String
+    @Binding var selection: Date
+    var body: some View {
+        DatePicker(datePickerTitle, selection: $selection, displayedComponents: .hourAndMinute)
+            .padding(.vertical, 6.5)
+            .padding(.horizontal, 16)
+    }
+}
+enum DividingType {
+    case naviTitleDivider
+    case listDivider
+}
+
+struct DividingRectangle: View {
+    let dividingType: DividingType
+
+    var body: some View {
+        switch dividingType {
+        case .naviTitleDivider:
+            return Rectangle()
+                .frame(height: 1)
+                .foregroundColor(.black75)
+        case .listDivider:
+            return Rectangle()
+                .frame(height: 0.5)
+                .foregroundColor(.black75)
+        }
     }
 }
 


### PR DESCRIPTION
<!--
---
name: PR template
about: 풀리퀘스트 보냅니다
title: "[feat][#0] 개발한 단위 기능의 이름"
labels: ''
assignees: ''

---
-->

📣 Assignees와 Labels를 우측에서 추가해 주세요!
# 📢 Description
<!-- 개발한 기능이 무엇인지, 수정한 버그가 무엇인지 설명해주세요 -->
- ListTitle: 리스트의 타이틀과 서브타이틀 View
- ToggleList: 색상 변경이 들어간 토글 리스트 셀 View
- DatePickerList: 시간 단위의 픽커 리스트 셀 View
- DividingRectangle: Divider() 대용 색상 및 두께를 커스텀한 Rectangle View
- 예정: 'feature/#36-SettingView'로 merge 후 내비게이션 관련 작업(내비게이션 백버튼, 내비게이션 타이틀, 내비게이션 바)
<img width="200" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-AhnNyeong/assets/127754551/de6bd306-674c-4d3b-bc23-b1906cf8c4ac">



# 🔑 Key Changes
<!-- 중심적으로 변화가 있는 부분을 명시해 주세요
- 버튼 생성
- 화면 로직 구현 등 -->
- 화면 UI 생성

# 📸 Screenshots
<!-- 개발한 해당 부분의 스크린샷이나 영상을 첨부해 주세요 -->

# 🙏 To Reviewers
<!-- 리뷰어가 확인하고 리뷰해 줬으면 좋겠는 부분을 알려주세요 -->
- 중복적인 코드가 많아 깔끔하지 않습니다. 
- 내비게이션 레이아웃 관련하여 화면의 Title인 '알림 설정'을 어떤 요소로 판단하면 좋을지 궁금합니다.
- 현 상태에서 내비게이션이 있을 경우의 레이아웃
<img width="200" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team-AhnNyeong/assets/127754551/a1497270-2715-4ef8-986c-b1309b04f6bc">